### PR TITLE
Bump Laravel to v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "^8.0",
+        "laravel/framework": "^9.0",
         "livewire/livewire": "^2.0"
     },
     "autoload": {


### PR DESCRIPTION
We are not using anything breaking from Laravel 8, so we could safely migrate to Laravel 9 in the next release.